### PR TITLE
Fix link to screenshot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Centreon Twitter](https://img.shields.io/twitter/follow/centreon.svg?style=social)](https://twitter.com/centreon) &nbsp;[![Centreon Labs Twitter](https://img.shields.io/twitter/follow/centreonlabs.svg?style=social)](https://twitter.com/centreonlabs) &nbsp;
 
-![Centreon ScreenShot](centreon-github-wall.jpg?raw=true "Title")
+![Centreon ScreenShot](centreon/centreon-github-wall.jpg?raw=true "Title")
 
 <h2> Introduction </h2>
 


### PR DESCRIPTION
When the new Centreon repository was created the image moved to the centreon subfolder. This PR fixes the image reference in the README file